### PR TITLE
Change "enviroment" to "environment"

### DIFF
--- a/environment.d.ts
+++ b/environment.d.ts
@@ -3,7 +3,7 @@ declare global {
         interface ProcessEnv {
             botToken: string;
             guildId: string;
-            enviroment: "dev" | "prod" | "debug";
+            environment: "dev" | "prod" | "debug";
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
         "resolveJsonModule": true,
         "importHelpers": true
     },
-    "include": ["src", "enviroment.d.ts"],
+    "include": ["src", "environment.d.ts"],
     "exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
The word "environment" is commonly misspelled without the "n".